### PR TITLE
Fix linter warnings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,46 +5,8 @@ import Home from "./pages/Home";
 import Create from "./pages/Create";
 import Details from "./pages/Details";
 import Embed from "./pages/Embed";
-import { ApolloProvider, Query } from 'react-apollo'
-import { gql } from 'apollo-boost'
 
 import "./App.css";
-
-
-
-const OMEN_QUERY = gql`
-{
-  question(id: "0x44c68bc0038635feb4bf7776c24f0c71748fa4bc3a73d3f94115959469da83a1") {
-    id
-    title
-    conditions {
-      id
-      fixedProductMarketMakers {
-        id
-        collateralToken
-      }
-    }
-  }
-}
-`
-// const ARGENT_QUERY = gql`
-//   query contractBasedAccounts(
-//     $where: ContractBasedAccount_filter!
-//     $orderBy: ContractBasedAccount_orderBy!
-//     $first: Int
-//   ) {
-//     contractBasedAccounts(
-//       first: $first
-//       where: $where
-//       orderBy: $orderBy
-//       orderDirection: desc
-//     ) {
-//       id
-//       timeCreated
-//     }
-//   }
-// `
-
 
 function App() {
     return (


### PR DESCRIPTION
CI tests failed because some JSlint warnings. To allow the CI build remove some unused variables, imports and missing dependencies.

- Remove unused variables.
- Remove imported Apollo dependencies from App.js.
- Fix missing dependency warning when using useEffect React Hook moving
  `fetchTokenInfo` to into the effect.

Resolves: #5